### PR TITLE
Refactor location address retrieval and update restaurant view titles…

### DIFF
--- a/lib/src/utils/location_helper.dart
+++ b/lib/src/utils/location_helper.dart
@@ -130,7 +130,11 @@ Future<String> getAddressFromGeopoint(GeoPoint geopoint) async {
     List<Placemark> placemarks =
         await placemarkFromCoordinates(geopoint.latitude, geopoint.longitude);
     if (placemarks.isNotEmpty) {
-      return "${placemarks.first.street}, ${placemarks.first.administrativeArea}, ${placemarks.first.country}";
+      Placemark place = placemarks.first;
+      String street = place.street ?? 'Unknown Street';
+      String administrativeArea = place.administrativeArea ?? 'Unknown Area';
+      String country = place.country ?? 'Unknown Country';
+      return "$street, $administrativeArea, $country";
     }
   } catch (e) {
     if (kDebugMode) {

--- a/lib/src/views/restaurant_view/restaurant_item_list_view.dart
+++ b/lib/src/views/restaurant_view/restaurant_item_list_view.dart
@@ -178,15 +178,6 @@ class RestaurantItemListViewState extends State<RestaurantItemListView> {
     final double sidePadding = isLargeScreen ? 20.0 : 10.0;
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          'Danh sách nhà hàng',
-          style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
-        ),
-        automaticallyImplyLeading: false,
-      ),
       body: _isLoadingLocation
           ? const Center(child: CircularProgressIndicator())
           : SingleChildScrollView(
@@ -195,11 +186,15 @@ class RestaurantItemListViewState extends State<RestaurantItemListView> {
               child: Column(
                 children: [
                   const SizedBox(height: 10),
-                  Text(
-                    'Nhà hàng gần bạn',
-                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      'Nhà hàng gần bạn',
+                      style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                      textAlign: TextAlign.left, // Align text to the left
+                    ),
                   ),
                   if (_nearbyRestaurants.isEmpty)
                     const Center(child: Text("Không có nhà hàng nào gần bạn.")),
@@ -239,11 +234,15 @@ class RestaurantItemListViewState extends State<RestaurantItemListView> {
                       ],
                     ),
                   const SizedBox(height: 10),
-                  Text(
-                    'Tất cả nhà hàng',
-                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      'Tất cả nhà hàng',
+                      style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                      textAlign: TextAlign.left, // Align text to the left
+                    ),
                   ),
                   GridView.builder(
                     shrinkWrap: true,

--- a/lib/src/views/user_view/profile_page_view.dart
+++ b/lib/src/views/user_view/profile_page_view.dart
@@ -78,7 +78,7 @@ class _ProfilePageViewState extends State<ProfilePageView> {
                 title: "Tổng quan",
                 children: [
                   _CustomListTile(
-                    title: "Danh sách nhà hàng",
+                    title: "Nhà hàng của bạn",
                     icon: Icons.store,
                     onTap: () {
                       if (user == null) {


### PR DESCRIPTION
This pull request includes several changes to improve the user interface and error handling in the application. The most important changes involve enhancing the address formatting in the location helper, removing the app bar from the restaurant list view, aligning text to the left in various views, and updating the profile page view.

### Improvements to address formatting:
* [`lib/src/utils/location_helper.dart`](diffhunk://#diff-149c01e601b85d269d91106df7934f3af35ef353d0d449d085b04682254654ecL133-R137): Modified the `getAddressFromGeopoint` method to handle null values for street, administrative area, and country by providing default values.

### User interface updates:
* [`lib/src/views/restaurant_view/restaurant_item_list_view.dart`](diffhunk://#diff-b192a1b9b5a5379753c58dfbcf58d3fc6927db0c3a5ec316abbb442438a8819eL181-L189): Removed the app bar from the `RestaurantItemListViewState` class to simplify the view.
* [`lib/src/views/restaurant_view/restaurant_item_list_view.dart`](diffhunk://#diff-b192a1b9b5a5379753c58dfbcf58d3fc6927db0c3a5ec316abbb442438a8819eL198-R197): Aligned the 'Nhà hàng gần bạn' text to the left and wrapped it in an `Align` widget for better layout control.
* [`lib/src/views/restaurant_view/restaurant_item_list_view.dart`](diffhunk://#diff-b192a1b9b5a5379753c58dfbcf58d3fc6927db0c3a5ec316abbb442438a8819eL242-R245): Aligned the 'Tất cả nhà hàng' text to the left and wrapped it in an `Align` widget for better layout control.
* [`lib/src/views/user_view/profile_page_view.dart`](diffhunk://#diff-2b352e7f0402842561ebf74c679ed04198bc7de06d31a3b31a0e7c64dcc0ac1fL81-R81): Updated the title of a list tile from "Danh sách nhà hàng" to "Nhà hàng của bạn" in the profile page view for better clarity.